### PR TITLE
Added examples to Get and Set a Tripping curve configuration examples

### DIFF
--- a/docs/zero_interactions_examples/01_basic_GET_call.py
+++ b/docs/zero_interactions_examples/01_basic_GET_call.py
@@ -17,21 +17,12 @@ import aiocoap
 # We'll be logging whatever is happening on screen, so it makes things easier to follow
 logging.basicConfig(level=logging.INFO)
 
-# Here we're keeping things really simple, asking the user to insert the
-# Blixt Zero device IP, so its easier to follow along.
-default_ip = "192.168.1.81"
-zero_ip_addr = input(f"Insert the target Zero IP (or press enter for default {default_ip}): ")
-
-if not zero_ip_addr:
-    zero_ip_addr = default_ip
-logging.info(f"Selected Target IP: {zero_ip_addr}")
-
-# Sleep, just for the sake of going slower
-time.sleep(1)
+# Here we're keeping things really simple, just add your zero ip (that can be found running example number 6)
+zero_ip_addr = "0.0.0.0"
 
 # Now let's go, we'll need the content format of the package
 # 30001 is the default value for Zero.
-# content_format = "30001" # content format is not used on GET requests.
+# content_format = "30001" # content format is not necessary on GET requests.
 target_endpoint = ".well-known/core"
 
 # To form the complete address, we'll format it in just one string here...

--- a/docs/zero_interactions_examples/02_protobuf_GET_call.py
+++ b/docs/zero_interactions_examples/02_protobuf_GET_call.py
@@ -25,21 +25,12 @@ from common.zc_messages.zc_messages_pb2 import *
 # We'll be logging whatever is happening on screen, so it makes things easier to follow
 logging.basicConfig(level=logging.INFO)
 
-# Here we're keeping things really simple, asking the user to insert the
-# Blixt Zero device IP, so its easier to follow along.
-default_ip = "192.168.1.81"
-zero_ip_addr = input(f"Insert the target Zero IP (or press enter for default {default_ip}): ")
-
-if not zero_ip_addr:
-    zero_ip_addr = default_ip
-logging.info(f"Selected Target IP: {zero_ip_addr}")
-
-# Sleep, just for the sake of going slower
-time.sleep(1)
+# Here we're keeping things really simple, just add your zero ip (that can be found running example number 6)
+zero_ip_addr = "0.0.0.0"
 
 # Now let's go, we'll need the content format of the package
 # 30001 is the default value for Zero.
-# content_format = "30001" # content format is not used on GET requests.
+# content_format = "30001" # content format is not necessary on GET requests.
 target_endpoint = "status"
 
 # To form the complete address, we'll format it in just one string here...

--- a/docs/zero_interactions_examples/04_protobuf_POST_ERROR_call.py
+++ b/docs/zero_interactions_examples/04_protobuf_POST_ERROR_call.py
@@ -2,43 +2,19 @@
 # Blixt Zero SG - Zero Example 01
 # Basic Call to Zero Example
 
-# Description:
-# This example shows you how NOT to issue a command to the Switching Gear
-# causing a encoding error.
-
-# Usually errors code shown on responses comming from the device are related
-# misencoding of the request packages or missing content format.
-# On this exercise we'll exemplify those most common problems we can find.
-
-# Async library is needed since the CoAP libary that we're using works async.
 import asyncio
 import logging
 import time
 
-# Extra non-default libraries
 import aiocoap
-
-# Import the previously compiled protobuf libraries
 from common.zc_messages.zc_messages_pb2 import *
+from common.request_zero import zero_post_request
 
-# We'll be logging whatever is happening on screen, so it makes things easier to follow
 logging.basicConfig(level=logging.INFO)
 
-# Here we're keeping things really simple, asking the user to insert the
-# Blixt Zero device IP, so its easier to follow along.
-default_ip = "192.168.212.33"
-zero_ip_addr = input(f"Insert the target Zero IP (or press enter for default {default_ip}): ")
+zero_ip_addr = "0.0.0.0"
 
-if not zero_ip_addr:
-    zero_ip_addr = default_ip
-logging.info(f"Selected Target IP: {zero_ip_addr}")
-
-# Sleep, just for the sake of going slower
-time.sleep(1)
-
-# Now let's go, we'll need the content format of the package
-# 30001 is the default value for Zero.
-content_format = "30001" # content format is not used on GET requests.
+content_format = "30001"
 target_endpoint = "device"
 
 # To form the complete address, we'll format it in just one string here...
@@ -46,52 +22,18 @@ complete_address = f"coap://{zero_ip_addr}/{target_endpoint}"
 
 logging.info(f"Preparing the POST request package to {complete_address}")
 
-async def zero_post_request(request_address, cf, payload, encode):
-    '''
-    We made an async function here, because the aiocoap library runs async,
-    so we need to keep things in async context.
-    - First Arg is the complete address of the request
-    - Second Arg is the content format
-    - Third Arg is the Payload
-    '''
-
-    if encode:
-        # 1 - Here a new instance of a Protobuf Message is created
-        zero_data = ZCMessage()
-
-        # 2 - Create the Protobuf Package
-        zero_data.req.cmd.cmd = payload
-
-        # 3 - Let's serialize that to send to the device
-        zero_payload = zero_data.SerializeToString()
-    else:
-        zero_payload = payload
-
-    # 4 - Make the POST request
-
-    CoAP_Context = await aiocoap.Context.create_client_context()
-
-    post_request = aiocoap.Message(code=aiocoap.POST, payload=zero_payload ,uri =request_address)
-    post_request.opt.content_format = cf
-
-    try:
-        response = await CoAP_Context.request(post_request).response
-        await CoAP_Context.shutdown()
-    except Exception as e:
-        logging.error(f"Failed to post {request_address} to device!")
-        logging.error(f"Error: {e}")
-        return
-    return response.payload
-
 
 # Here we create the payload before sending it. The possible payloads are already
 # determined by the ProtocolBuffer library.
-request_payload = ZCDeviceCmd.ZC_DEVICE_CMD_TOGGLE
+device_cmd = ZCDeviceCmd.ZC_DEVICE_CMD_TOGGLE
+request_cmd = ZCRequestDeviceCmd(cmd=device_cmd)
+request = ZCRequest(cmd=request_cmd)
 content_format = "201" # This is wrong on purpose!
 
 print(f"\n---[ Example of Misconfigured Content Format ]---\n")
 
 print("The first error message is due to: Wrong Content Format Code")
+
 print(f"The content format was purposefully set to {content_format} when it should be 30001.\n")
 input("Press enter to see the result...\n")
 
@@ -99,7 +41,7 @@ input("Press enter to see the result...\n")
 logging.info(f"Waiting for the async request to return...")
 
 # So now we will be sending the payload we created and getting the response
-result = asyncio.run(zero_post_request(complete_address, content_format, request_payload, True))
+result = asyncio.run(zero_post_request(complete_address, content_format, request))
 
 logging.info(f"Decoding the message received...\n")
 zero_data = ZCMessage()

--- a/docs/zero_interactions_examples/05_zero_interactions_demo.py
+++ b/docs/zero_interactions_examples/05_zero_interactions_demo.py
@@ -9,7 +9,7 @@ from common.zc_messages.zc_messages_pb2 import *
 
 # Makes a new instance of the Switching Gear Device
 # change this address for the address of the device you wish to interact with!
-device_addr = "192.168.212.33"
+device_addr = "0.0.0.0"
 zeroSG = CoAP_Device(device_addr)
 
 

--- a/docs/zero_interactions_examples/07_protobuf_POST_SetConfig.py
+++ b/docs/zero_interactions_examples/07_protobuf_POST_SetConfig.py
@@ -1,0 +1,66 @@
+# Daniel ZDM | Blixt Tech | 17 Feb 2025
+# Blixt Zero SG - Zero Example 01
+# Basic Call to Zero Example
+
+# Description:
+# This script shows you how to configure a tripping curve using python
+
+import asyncio
+import logging
+import time
+
+import aiocoap
+from common.zc_messages.zc_messages_pb2 import *
+from common.request_zero import zero_post_request
+
+logging.basicConfig(level=logging.INFO)
+zero_ip_addr = "0.0.0.0"
+
+target_endpoint = "config"
+content_format = "30001"
+
+complete_address = f"coap://{zero_ip_addr}/{target_endpoint}"
+
+logging.info(f"Preparing POST request to {complete_address}")
+
+# Set each point of the curve
+point1 = ZCCurvePoint(limit=2000, duration=3600000)
+point2 = ZCCurvePoint(limit=3000, duration=1800000)
+point3 = ZCCurvePoint(limit=4000, duration=600000)
+point4 = ZCCurvePoint(limit=10000, duration=100)
+
+# Create a Curve Config isntance
+curve_config = ZCCurveConfig()
+
+# Wrap the curve points into the curve config
+curve_config.points.extend([point1, point2, point3, point4])
+# Add for which direction your configuration is valid for
+curve_config.direction = ZCFlowDirection.ZC_FLOW_DIRECTION_FORWARD
+
+print(curve_config.ListFields())
+
+csom_config = ZCCsomConfig()
+csom_config.enabled = False
+
+zc_config = ZCConfig()
+# zc_config.csom.CopyFrom(csom_config)
+zc_config.curve.CopyFrom(curve_config)
+
+set_config_req = ZCRequestSetConfig()
+set_config_req.config.CopyFrom(zc_config)
+
+zc_request = ZCRequest()
+zc_request.set_config.CopyFrom(set_config_req)
+
+logging.info(f"Waiting for the async request to return...")
+
+result = asyncio.run(zero_post_request(complete_address, content_format, zc_request))
+
+logging.info(f"Decoding the message received...")
+zero_data = ZCMessage()
+
+zero_data.ParseFromString(result)
+
+print(zero_data.ListFields())
+
+logging.info(f"Finished, end of program.")

--- a/docs/zero_interactions_examples/08_protobuf_POST_GetConfig.py
+++ b/docs/zero_interactions_examples/08_protobuf_POST_GetConfig.py
@@ -1,0 +1,71 @@
+# Daniel ZDM | Blixt Tech | 17 Feb 2025
+# Blixt Zero SG - Zero Example 01
+# Basic Call to Zero Example
+
+# Description:
+
+import asyncio
+import logging
+import time
+
+import aiocoap
+from common.zc_messages.zc_messages_pb2 import *
+
+logging.basicConfig(level=logging.INFO)
+zero_ip_addr = "0.0.0.0"
+
+content_format = "30001"
+target_endpoint = "config"
+
+complete_address = f"coap://{zero_ip_addr}/{target_endpoint}"
+
+logging.info(f"Preparing POST request to {complete_address}")
+
+async def zero_post_request(request_address, cf, payload):
+    '''
+    We made an async function here, because the aiocoap library runs async,
+    so we need to keep things in async context.
+    - First Arg is the complete address of the request
+    - Second Arg is the content format
+    - Third Arg is the Payload
+    '''
+
+    zero_data = ZCMessage(req=payload)
+
+    zero_payload = zero_data.SerializeToString()
+
+
+    CoAP_Context = await aiocoap.Context.create_client_context()
+
+    post_request = aiocoap.Message(code=aiocoap.POST, payload=zero_payload ,uri =request_address)
+    post_request.opt.content_format = cf
+
+    try:
+        response = await CoAP_Context.request(post_request).response
+    except Exception as e:
+        return(f"Failed to post {request_address} to device!")
+    return response.payload
+
+
+get_config_request = ZCRequestGetConfig()
+get_config_request.curve.direction = ZCFlowDirection.ZC_FLOW_DIRECTION_FORWARD  # Specify direction if needed
+
+zc_request = ZCRequest()
+zc_request.get_config.CopyFrom(get_config_request)
+
+
+logging.info(f"Waiting for the async request to return...")
+
+
+result = asyncio.run(zero_post_request(complete_address, content_format, zc_request))
+
+logging.info(f"Decoding the message received...")
+zero_data = ZCMessage()
+
+zero_data.ParseFromString(result)
+
+
+print(zero_data.ListFields())
+
+
+logging.info(f"Finished, end of program.")

--- a/docs/zero_interactions_examples/common/request_zero.py
+++ b/docs/zero_interactions_examples/common/request_zero.py
@@ -1,0 +1,48 @@
+
+import logging
+import time
+
+import aiocoap
+from common.zc_messages.zc_messages_pb2 import *
+
+logging.basicConfig(level=logging.INFO)
+
+async def zero_get_request(request_address):
+    '''
+    We made an async function here, because the aiocoap library runs async,
+    so we need to keep things in async context.
+    - First Arg is the complete address of the request
+    - Second Arg is the content format
+    '''
+    CoAP_context = await aiocoap.Context.create_client_context()
+    zero_request = aiocoap.Message(code=aiocoap.GET, uri=request_address)
+    try:
+        logging.info(f"Atempting GET Request {request_address}")
+        time.sleep(1)
+        response = await CoAP_context.request(zero_request).response
+    except:
+        logging.warning(f"Failed to request data to {request_address}!")
+    return response.payload
+
+async def zero_post_request(request_address, cf, payload):
+    '''
+    We made an async function here, because the aiocoap library runs async,
+    so we need to keep things in async context.
+    - First Arg is the complete address of the request
+    - Second Arg is the content format
+    - Third Arg is the Payload
+    '''
+    zero_data = ZCMessage()
+    zero_data.req.CopyFrom(payload)
+    zero_payload = zero_data.SerializeToString()
+    CoAP_Context = await aiocoap.Context.create_client_context()
+
+    post_request = aiocoap.Message(code=aiocoap.POST, payload=zero_payload ,uri =request_address)
+    post_request.opt.content_format = cf
+
+    try:
+        response = await CoAP_Context.request(post_request).response
+    except Exception as e:
+        return(f"Failed to post {request_address} to device!")
+    return response.payload
+


### PR DESCRIPTION
# Examples Update
## Examples reworked and added more!

- Simplified some examples
- Made code cleaner moving the request (GET and POST) into common directory
- Added examples 07 and 08
    - Example 07 is used to Set a new tripping configuration curve to the Zero
    - Example 08 is used to Get the actual tripping configuration curve from the Zero

Some other enhancements were done around removing excessive comments.
