### PR TITLE
feat(config): make recovery reset timeout configurable 

### DIFF
--- a/docs/proto_files/zc_messages.proto
+++ b/docs/proto_files/zc_messages.proto
@@ -126,11 +126,12 @@ message ZCCurveConfig {
 
 /* Hardware-based overcurrent protection configuration. */
 message ZCOcpHwConfig {
-	uint32 limit	    = 1; /* Current limit in amperes. */
-	uint32 filter	    = 2; /* Jitter filter in nano seconds. */
-	uint32 rec_delay    = 3; /* Recovery time delay in microseconds. */
-	uint32 rec_attempts = 4; /* Number of recovery attempts. */
-	bool rec_en	    = 5; /* Set to true if recovery is enabled. */
+	uint32 limit	    		= 1; /* Current limit in amperes. */
+	uint32 filter	    		= 2; /* Jitter filter in nano seconds. */
+	uint32 rec_delay    		= 3; /* Recovery time delay in microseconds. */
+	uint32 rec_attempts 		= 4; /* Number of recovery attempts. */
+	bool rec_en	    			= 5; /* Set to true if recovery is enabled. */
+	uint32 rec_reset_timeout	= 6; /* Recovery reset timer in milliseconds. */
 }
 
 /* Over/under voltage protection configuration. */

--- a/modules/bcb/zephyr/include/lib/bcb_coap_handlers.h
+++ b/modules/bcb/zephyr/include/lib/bcb_coap_handlers.h
@@ -34,7 +34,7 @@ int bcb_coap_handlers_version_get(struct coap_resource *resource, struct coap_pa
 int bcb_coap_handlers_status_get(struct coap_resource *resource, struct coap_packet *request,
 				 struct sockaddr *addr, socklen_t addr_len);
 int bcb_coap_handlers_status_post(struct coap_resource *resource, struct coap_packet *request,
-				 struct sockaddr *addr, socklen_t addr_len);
+				  struct sockaddr *addr, socklen_t addr_len);
 void bcb_coap_handlers_status_notify(struct coap_resource *resource,
 				     struct coap_observer *observer);
 int bcb_coap_handlers_config_post(struct coap_resource *resource, struct coap_packet *request,

--- a/modules/bcb/zephyr/include/lib/bcb_tc_def_msm.h
+++ b/modules/bcb/zephyr/include/lib/bcb_tc_def_msm.h
@@ -22,7 +22,7 @@ typedef enum {
 	BCB_TC_DEF_EV_SW_CLOSED,
 	BCB_TC_DEF_EV_SUPPLY_TIMER,
 	BCB_TC_DEF_EV_REC_TIMER,
-	BCB_TC_DEF_EV_REC_RESET_TIMER  
+	BCB_TC_DEF_EV_REC_RESET_TIMER
 } bcb_tc_def_event_t;
 
 /**
@@ -55,6 +55,7 @@ typedef enum {
 	BCB_TC_DEF_MSM_CSOM_NONE = 0, /**< No operation mode. */
 	BCB_TC_DEF_MSM_CSOM_MOD, /**< Modulation control operation mode. */
 	BCB_TC_DEF_MSM_CSOM_END
+
 } bcb_tc_def_msm_csom_t;
 
 /**
@@ -65,6 +66,8 @@ typedef struct bcb_msm_config {
 	bool rec_enabled; /**< Set to true if recovery is enabled. */
 	uint16_t rec_attempts; /**< Number of recovery attempts. */
 	uint32_t rec_delay; /**< Recovery delay in microseconds. */
+	uint32_t rec_reset_timeout; /**< Recovery reset timeout in milliseconds. */
+
 } bcb_tc_def_msm_config_t;
 
 /**

--- a/modules/bcb/zephyr/lib/Kconfig.lib
+++ b/modules/bcb/zephyr/lib/Kconfig.lib
@@ -19,6 +19,13 @@ config BCB_TRIP_CURVE_DEFAULT_RECOVERY_RESET_TIMER_TIMEOUT
     int "Default recovery reset timer timeout (ms)"
     default 2000  
 
+config BCB_TRIP_CURVE_DEFAULT_RECOVERY_RESET_TIMER_TIMEOUT_MIN
+    int "Minimum recovery reset timer timeout (ms)"
+    default 100
+
+config BCB_TRIP_CURVE_DEFAULT_RECOVERY_RESET_TIMER_TIMEOUT_MAX
+    int "Maximum recovery reset timer timeout (ms)"
+    default 10000
 
 menu "Timing"
 	config BCB_LIB_ETIME_SECOND

--- a/modules/bcb/zephyr/lib/bcb_coap_handlers.c
+++ b/modules/bcb/zephyr/lib/bcb_coap_handlers.c
@@ -469,6 +469,7 @@ static inline void encode_config_ocp(zc_ocp_hw_config_t *config)
 	config->rec_en = msm_config.rec_enabled;
 	config->rec_attempts = msm_config.rec_attempts;
 	config->rec_delay = msm_config.rec_delay;
+	config->rec_reset_timeout = msm_config.rec_reset_timeout;
 }
 
 static inline void encode_config_ini_state(zc_ini_state_config_t *config)
@@ -645,6 +646,7 @@ static inline int apply_config_ocp(zc_ocp_hw_config_t *config)
 	msm_config.rec_enabled = config->rec_en;
 	msm_config.rec_attempts = config->rec_attempts;
 	msm_config.rec_delay = config->rec_delay;
+	msm_config.rec_reset_timeout = config->rec_reset_timeout;
 
 	return bcb_tc_def_msm_config_set(&msm_config);
 }

--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       path: zephyr-os
       west-commands: scripts/west-commands.yml
     - name: zero-control-messages
-      revision: 4a3d4fa7acbcc6c48a765b7028bb49d73daafe9c
+      revision: 18eae19d74183d3e0fcaa8d78c559d3dff892f60
       remote: blixttech
       path: modules/lib/zc-messages
 


### PR DESCRIPTION
- Updated config_set() with timeout validation
- Store timeout value in EEPROM using  store_config()
- Maintain default of 2000ms on first boot
-  Implement CoAP rec reset timeout configuration
- Update west.yml
- Adding the min and max timeout in the constant defined in Kconfig
